### PR TITLE
177294339 prevent teachers updating email

### DIFF
--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -11,6 +11,8 @@ class TeachersController < ApplicationController
   def new
     @teacher = Teacher.new
     @school = School.new
+    @action = "Submit"
+    @readonly = false
   end
 
   def create
@@ -59,11 +61,19 @@ class TeachersController < ApplicationController
     @teacher = Teacher.find(params[:id])
     @school = @teacher.school
     @status = is_admin? ? "Admin" : "Teacher"
+    @action = "Update"
+    @readonly = !is_admin?
   end
 
   def update
     @teacher = Teacher.find(params[:id])
     @school = @teacher.school
+    old_email, old_snap = @teacher.email, @teacher.snap
+    new_email, new_snap = teacher_params[:email], teacher_params[:snap]
+    if ((old_email != new_email) || (old_snap != new_snap)) && !is_admin?
+      redirect_to edit_teacher_path(current_user.id), alert: "Failed to update your information. If you want to change your email or Snap! username, please contact an admin."
+      return
+    end
     @teacher.update(teacher_params)
     @school.update(school_params)
     @teacher.save!

--- a/app/controllers/teachers_controller.rb
+++ b/app/controllers/teachers_controller.rb
@@ -100,7 +100,6 @@ class TeachersController < ApplicationController
   end
 
   def deny
-    # TODO: Require admin helper.
     # TODO: Check if teacher is already validated (MAYBE)
     # TODO: Clean this up so the counter doesn't need to be manually incremented.
     teacher = Teacher.find(params[:id])

--- a/app/views/teachers/_form.html.erb
+++ b/app/views/teachers/_form.html.erb
@@ -19,14 +19,14 @@
       <div class='col-6'>
         <%= f.label :email, "School Email", class: "label-required" %>
         <%= f.text_field :email, placeholder: 'alonzo@snap.berkeley.edu', class: 'form-control',
-          required: true, type: :email %>
+          required: true, type: :email, readonly: @readonly %>
       </div>
 
       <div class='col-6'>
         <%= f.label :snap do %>
           Snap<i>!</i> Username
         <% end %>
-        <%= f.text_field :snap, placeholder: "alonzo", class: "form-control" %>
+        <%= f.text_field :snap, placeholder: "alonzo", class: "form-control", readonly: @readonly %>
       </div>
     </div>
 
@@ -108,6 +108,6 @@
   <% end %>
 
   <div>
-    <%= f.submit 'Submit', class: 'btn btn-primary' %>
+    <%= f.submit @action, class: 'btn btn-primary', id: "#action-button" %>
   </div>
 <% end %>

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -54,7 +54,7 @@ Scenario: Edit teacher info as an admin
   When  I go to the edit page for Joseph Mamoa
   Then  I should see "Joseph"
   And   I enter my "First Name" as "Joe"
-  And   I press "Submit"
+  And   I press "Update"
   Then I see a confirmation "Successfully updated information"
 
 Scenario: Not logged in should not have access to edit

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -252,3 +252,7 @@ end
 Then /^show me the page$/ do
   save_and_open_page
 end
+
+Then /^(?:|I )should see a button named "([^"]*)"$/ do |text|
+  page.should have_button(text)
+end

--- a/features/teacher.feature
+++ b/features/teacher.feature
@@ -22,7 +22,7 @@ Scenario: Logging in as a teacher should be able to edit their info
   And   I enter my "City" as "Cupertino"
   And   I select "CA" from "State"
   And   I enter my "School Website" as "https://chs.fuhsd.org"
-  And   I press "Submit"
+  And   I press "Update"
   Then  I see a confirmation "Successfully updated your information"
   Then  the "First Name" field should contain "Joe"
 

--- a/features/teacher.feature
+++ b/features/teacher.feature
@@ -41,3 +41,16 @@ Scenario: Logged in teacher can only edit their own information
   When I go to the edit page for Jane Austin
   Then I should see "You can only edit your own information"
 
+Scenario: Logging in as a teacher should see "Update" instead of "Submit" when editing info
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                     |
+  | Joseph     | Mamoa     | false | testteacher@berkeley.edu  |
+  Given I have a teacher email
+  Given I am on the BJC home page
+  Then I should see a button named "Submit"
+  Given I follow "Log In"
+  Then I can log in with Google
+  Then I should see a button named "Update"

--- a/features/teacher.feature
+++ b/features/teacher.feature
@@ -54,3 +54,20 @@ Scenario: Logging in as a teacher should see "Update" instead of "Submit" when e
   Given I follow "Log In"
   Then I can log in with Google
   Then I should see a button named "Update"
+
+Scenario: Frontend should not allow Teacher to edit their email
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                     | snap |
+  | Jane       | Austin    | false | testteacher@berkeley.edu  | Jane |
+  Given I have a teacher email
+  Given I am on the BJC home page
+  And I follow "Log In"
+  Then I can log in with Google
+  When I go to the edit page for Jane Austin
+  And  I enter my "School Email" as "wrong@berkeley.edu"
+  And  I enter my "Snap! Username" as "wrong"
+  Then the "School Email" field should contain "testteacher@berkeley.edu"
+  Then the "Snap!" field should contain "Jane"

--- a/spec/controllers/teachers_controller_spec.rb
+++ b/spec/controllers/teachers_controller_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe TeachersController, type: :controller do
     fixtures :all
 
     before(:each) do
-        ApplicationController.any_instance.stub(:require_admin).and_return(true)
         ApplicationController.any_instance.stub(:require_login).and_return(true)
     end
 
     it "able to deny an application" do
+        ApplicationController.any_instance.stub(:require_admin).and_return(true)
         long_app = Teacher.find_by(first_name: "Short")
         post :deny, :params => { :id => long_app.id }
         long_app = Teacher.find_by(first_name: "Short")
@@ -16,9 +16,22 @@ RSpec.describe TeachersController, type: :controller do
     end
 
     it "able to accept an application" do
+        ApplicationController.any_instance.stub(:require_admin).and_return(true)
         long_app = Teacher.find_by(first_name: "Short")
         post :validate, :params => { :id => long_app.id }
         long_app = Teacher.find_by(first_name: "Short")
         expect(long_app.display_application_status).to eq "Validated"
+    end
+
+    it "doesn't allow teacher to change their snap or email" do
+      ApplicationController.any_instance.stub(:require_edit_permission).and_return(true)
+      ApplicationController.any_instance.stub(:is_admin?).and_return(false)
+      ApplicationController.any_instance.stub(:current_user).and_return(Teacher.find_by(first_name: "Short"))
+      short_app = Teacher.find_by(first_name: "Short")
+      post :update, :params => { :id => short_app.id, :teacher => {:id => short_app.id, :email => "wrong@berkeley.edu"} }
+      post :update, :params => { :id => short_app.id, :teacher => {:id => short_app.id, :snap => "wrong"} }
+      short_app = Teacher.find_by(first_name: "Short")
+      expect(short_app.email).to eq 'short@long.com'
+      expect(short_app.snap).to eq 'song'
     end
 end


### PR DESCRIPTION
add front-end and back-end features to prevent teachers from updating their email and Snap!.
Admins can do it though