### PR TITLE
Fixed overwriting info w/email bug + prevent creating teachers with used emails

### DIFF
--- a/db/migrate/20210327050905_change_email_unique.rb
+++ b/db/migrate/20210327050905_change_email_unique.rb
@@ -1,0 +1,9 @@
+class ChangeEmailUnique < ActiveRecord::Migration[5.2]
+  def up
+    add_index :teachers, :email, unique: true
+  end
+
+  def down
+    remove_index :teachers, :email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_18_034405) do
+ActiveRecord::Schema.define(version: 2021_03_27_050905) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2021_03_18_034405) do
     t.integer "education_level", default: -1
     t.string "application_status", default: "Pending"
     t.index ["email", "first_name"], name: "index_teachers_on_email_and_first_name"
+    t.index ["email"], name: "index_teachers_on_email", unique: true
   end
 
 end

--- a/features/form_submission.feature
+++ b/features/form_submission.feature
@@ -25,20 +25,6 @@ Scenario: Correctly filling out and succesful form submission
     And   I press "Submit"
     Then  I see a confirmation "Thanks for signing up for BJC"
 
-Scenario: Filling a new form with existing info shows and updated confirmation.
-    Given I am on the BJC home page
-    And   I enter my "First Name" as "Ye"
-    And   I enter my "Last Name" as "Wang"
-    And   I enter my "School Email" as "teacher@example.edu"
-    And   I set my status as "I am teaching BJC as an AP CS Principles course."
-    And   I set my education level target as "High School"
-    And   I enter my "School Name" as "Cupertino High School"
-    And   I enter my "City" as "Cupertino"
-    And   I select "CA" from "State"
-    And   I enter my "School Website" as "https://chs.fuhsd.org"
-    And   I press "Submit"
-    Then  I see a confirmation "Thanks! We have updated your information."
-
 Scenario: Not Correctly filling out and unsuccesful form submission
     Given I am on the BJC home page
     And   I enter my "First Name" as "Kimberly"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -14,6 +14,7 @@ module NavigationHelpers
     case page_name
 
     when /^the (BJC )?home\s?page$/ then '/'
+    when /^the new teachers page$/ then new_teacher_path
     when /^the edit page for (.*) (.*)$/i
       edit_teacher_path(Teacher.find_by(first_name:$1, last_name:$2))
     # Add more mappings here.

--- a/features/teacher.feature
+++ b/features/teacher.feature
@@ -28,6 +28,58 @@ Scenario: Logging in as a teacher should be able to edit their info
   Then  the "First Name" field should contain "Joe"
   Then  there is a TEALS email
 
+Scenario: Logged in teacher can fill a new form with their info
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                    | school      |
+  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
+  Given I have a teacher email
+  Given I am on the BJC home page
+  And   I follow "Log In"
+  Then  I can log in with Google
+  When  I go to the new teachers page
+  And   I enter my "First Name" as "Joe"
+  And   I enter my "Last Name" as "Mamoa"
+  And   I enter my "School Email" as "testteacher@berkeley.edu"
+  And   I enter my "Snap! Username" as "alonzo"
+  And   I set my status as "I am teaching BJC as an AP CS Principles course."
+  And   I set my education level target as "High School"
+  And   I enter my "School Name" as "Cupertino High School"
+  And   I enter my "City" as "Cupertino"
+  And   I select "CA" from "State"
+  And   I enter my "School Website" as "https://chs.fuhsd.org"
+  And   I press "Submit"
+  Then  I see a confirmation "Successfully updated your information"
+  And   I am on the edit page for Joe Mamoa
+
+  Scenario: Logged in teacher cannot change Snap from new form path
+  Given the following schools exist:
+  |       name      |     city     |  state  |            website            |
+  |   UC Berkeley   |   Berkeley   |   CA    |   https://www.berkeley.edu    |
+  Given the following teachers exist:
+  | first_name | last_name | admin | email                    | school      |
+  | Joseph     | Mamoa     | false | testteacher@berkeley.edu | UC Berkeley |
+  Given I have a teacher email
+  Given I am on the BJC home page
+  And   I follow "Log In"
+  Then  I can log in with Google
+  When  I go to the new teachers page
+  And   I enter my "First Name" as "Joe"
+  And   I enter my "Last Name" as "Mamoa"
+  And   I enter my "School Email" as "testteacher@berkeley.edu"
+  And   I enter my "Snap! Username" as "not_alonzo"
+  And   I set my status as "I am teaching BJC as an AP CS Principles course."
+  And   I set my education level target as "High School"
+  And   I enter my "School Name" as "Cupertino High School"
+  And   I enter my "City" as "Cupertino"
+  And   I select "CA" from "State"
+  And   I enter my "School Website" as "https://chs.fuhsd.org"
+  And   I press "Submit"
+  Then  I see a confirmation "Failed to update your information"
+  And   I am on the edit page for Joseph Mamoa
+
 Scenario: Logged in teacher can only edit their own information
   Given the following schools exist:
   |       name      |     city     |  state  |            website            |


### PR DESCRIPTION
app/controllers/teachers_controller.rb -- removed a lot of code that was either causing the bug or that was unnecessary, should display an alert now when overwriting is attempted
db/migrate/20210327050905_change_email_unique.rb and db/schema.rb -- making teacher email unique
features/form_submission.feature -- remove outdated feature; Steven has testing in his PR that extends this
features/support/paths.rb -- pathing for teacher testing
features/teacher.feature -- new testing

Side note -- this also fixes all maintainability issues within CodeClimate; @tommywei110 if you could remove babel.config.js from being monitored too that would be great (since it's just a part of webpacker and not our actual code)