### PR TITLE
Added Teacher details to schools page

### DIFF
--- a/app/views/schools/index.html.erb
+++ b/app/views/schools/index.html.erb
@@ -7,22 +7,59 @@
       <th scope="col">Location</th>
       <th scope="col">Website</th>
       <th scope="col">Teachers Count</th>
-      <th scope="col">First Teacher</th>
+      <th scope="col"></th>
     </tr>
   </thead>
   <tbody>
-    <% @schools.each do |school| %>
-    <tr>
-      <td><%= school.name %></td>
-      <td><%= school.location %></td>
-      <td>
-        <a href="<%= school.website %>" target="_blank">
-          <%= school.website %>
-        </a>
-      </td>
-      <td><%= school.teachers_count %></td>
-      <td ata-sort="<%= school.created_at %>"><%= school.created_at.strftime("%b %d, %Y") %></td>
-    </tr>
+    <% @schools.each_with_index do |school, index| %>
+      <tr>
+        <td><%= school.name %></td>
+        <td><%= school.location %></td>
+        <td>
+          <a href="<%= school.website %>" target="_blank">
+            <%= school.website %>
+          </a>
+        </td>
+        <td><%= school.teachers_count %></td>
+        <td>
+          <button class="btn btn-default dropdown-arrow" type="button" data-toggle="collapse" data-target="<%="#details_#{index}"%>" onclick> 
+            ▼
+          </button>
+        </td>
+      </tr>
+            
+      <tr class="collapse" id=<%="details_#{index}"%>>
+        <td colspan="6">
+          <table class="table">
+            <thead class="table-light">
+              <tr class="table-light">
+                <th colspan="5">Teacher Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% school.teachers.each do |teacher| %>
+                <tr class="table-light">
+                  <td>Name: <%= teacher.first_name + " " + teacher.last_name %> </td>
+                  <td>Email: <%= teacher.email %></td>
+                  <td>Education: <%= teacher.display_education_level %></td>
+                  <td>Status: <%= teacher.display_application_status%></td>
+                  <td>Date Submitted: <%= teacher.created_at.strftime("%b %d, %Y") %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </td>
+      </tr>
     <% end %>
   </tbody>
 </table>
+
+<script type="text/javascript">
+  $(function() {
+    $(".dropdown-arrow").click(function() {
+      $(this).text(function(i, text) {
+        return text === "▲" ? "▼": "▲";
+      })
+    });
+  })
+</script>


### PR DESCRIPTION
I replaced the "First Teacher column with a new dropdown menu which displays all the teachers from a particular schools. I didn't feel like it was necessary to present verbose information, as there is already a teachers show page, so I decided to put plain text for the teacher information. I couldn't figure out how to redo the striping on the table, but I think it looks alright.

![image](https://user-images.githubusercontent.com/46944677/115971361-de1ba680-a4fc-11eb-8fc3-c46a561f0459.png)
